### PR TITLE
Add draft directories to .gitignore to tidy up source control 0048

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@
 temp.backup
 temp.import
 /docs/pages.draft
+/docs/pages.draft.2
+/docs/posts.drafts
+/page.drafts.in.document.format
+/docs/root.drafts
+/docs/assets.drafts
 temp.draft
 temp.original


### PR DESCRIPTION

- Closes #48 

Adds draft directories to `.gitignore`.

`prod` was set as default branch so this change was inadvertently merged to `prod`. I reset the head and am now redoing the merge with `gh-pages-dev`. I have changed the default branch for merges to `gh-pages-dev` so I won't keep inadvertently merge with `prod` instead of `gh-pages-dev`.

So this is a second PR in order to merge to the correct branch.