### PR TITLE
PR: Edit the config file to have only a 'Project' header for the navigation menu 0060

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,8 +40,7 @@ plugins:
 
 # Set Navigation Menu
 header_pages:
-  - pages/realtor-app.md
-  - profile.md
+  - pages/project.md
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to


### PR DESCRIPTION

- closes #60 

Changed the `_config.yml` file to only refer to 'Project' page.
Removed references to 'Profile' page and 'Realtor-app' page.


