### PR TITLE
PR: remove app feature item list from 'Brief Description' on Project page 0065

### DIFF
--- a/docs/pages/project.md
+++ b/docs/pages/project.md
@@ -12,10 +12,6 @@ layout: page
 
 **Brief Description:**
  The app is a REST API built in the Node.js framework Nest.js, which queries and updates a Postgres database. The app allows a user to make http requests to a set of endpoints which query available realty properties.
-- The user can request a full list of available properties.
-- The user can also filter the list of properties based on the various attributes of the properties, such as price, city, and property type.
-- Users with a REALTOR role can create, update, and delete realty listings.
-- Users can message the realtor for the property with inquiries.
 
 
 **Technology Stack:**


### PR DESCRIPTION

- Closes #65 

Removed the list of specific functions that the app does, from the realtor app section of the Project page.

