### PR TITLE
PR: Make content changes to project and project overview pages 0067

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,11 @@ layout: home
 
 Hello! My name is Mark. I'm a software engineer.
 
-This website showcases a web application project. Please feel free to contact me at <a href="mailto:mark.wiltberger@gmail.com">mark.wiltberger@gmail.com</a>.
+This website showcases a <a href="/pages/project">web application project</a>. Please feel free to contact me at <a href="mailto:mark.wiltberger@gmail.com">mark.wiltberger@gmail.com</a>.
 
-<div style="display: flex; justify-content: center; align-items: center;"> <span style="font-weight: bold;"><a href="pages/project">Project</a></span> </div>
+<div  style="text-align: center;"><a href="/pages/project"><img src="/assets/realtor-app-concept.png"  alt="Realtor App concept" style="width: 240px; height: auto;" /></a></div>
+<div style="display: flex; justify-content: center; align-items: center;"> 
+<span style="font-weight: bold;"><a href="pages/project">Project</a></span>
+</div>
 
 

--- a/docs/pages/project.md
+++ b/docs/pages/project.md
@@ -5,11 +5,15 @@ layout: page
 
 ---
 
-## Realtor App Backend Project
+## [Realtor App Backend Project](/pages/realtor-app-backend-project)
 
-<div  style="text-align: center;"><img src="/assets/realtor-app-concept.png"  alt="Realtor App concept" style="width: 480px; height: auto;" /></div>
+<div  style="text-align: center;"><a href="/pages/realtor-app-backend-project"><img src="/assets/realtor-app-concept.png"  alt="Realtor App concept" style="width: 480px; height: auto;" /></a></div>
 <br />  
 
+<br>
+**[Project Write-up](/pages/realtor-app-backend-project):** See a full write-up of the project, including the GitHub repository, features, architecture, and testing.
+
+<br>
 **Brief Description:**
  The app is a REST API built in the Node.js framework Nest.js, which queries and updates a Postgres database. The app allows a user to make http requests to a set of endpoints which query available realty properties.
 
@@ -20,8 +24,6 @@ layout: page
 - **Database:** Postgres
 - **Other Tools:** JWT for authentication
 
-<br>
-**Project Write-up:** See a full write-up of the project, including the GitHub repository, features, architecture, and testing, [here](/pages/realtor-app-backend-project).
 
 <br>
 

--- a/docs/pages/realtor-app-backend-project.md
+++ b/docs/pages/realtor-app-backend-project.md
@@ -9,13 +9,9 @@ layout: page
 
 ## Quick Links
 
-- **GitHub Repository:** See the code at the GitHub repository [**here**](https://github.com/MarkWiltberger/vue-nest-web-app__realtor-app){:target="_blank"}.
-
-
-- **Application Demo:** Try out the application using Postman [**here**](https://www.postman.com/science-meteorologist-84254413/realtor-app-online/overview){:target="_blank"}.
-
-
-- **Application Documentation:** See the API documentation on Postman [**here**](https://www.postman.com/science-meteorologist-84254413/realtor-app-online/documentation/gu1pgpa/realtor-app-online){:target="_blank"}.
+- **[GitHub Repository](https://github.com/MarkWiltberger/vue-nest-web-app__realtor-app){:target="_blank"}:** See the code at the GitHub repository.
+- **[Application Documentation](https://www.postman.com/science-meteorologist-84254413/realtor-app-online/documentation/gu1pgpa/realtor-app-online){:target="_blank"}:** See the API documentation on Postman.
+- **[Application Demo](https://www.postman.com/science-meteorologist-84254413/realtor-app-online/overview){:target="_blank"}:** Try out the application using Postman.
 
 <br>
 
@@ -60,7 +56,7 @@ The app is a REST API built in the Node.js framework Nest.js, which queries and 
 **High-Level Architecture Diagram:**
 - The backend application is part of a three-layer stack consisting of a web application frontend, the backend, and a Postgres database:
 <br />  
-<div  style="text-align: center;"><a href="/assets/tech-stack-diagram.png"><img src="/assets/tech-stack-diagram.png"  alt="Tech Stack Diagram" style="width: 480px; height: auto;" /></a></div>
+<div  style="text-align: center;"><a href="/assets/tech-stack-diagram.png"><img src="/assets/tech-stack-diagram.png"  alt="Tech Stack Diagram" style="width: 480px; height: auto;" /></a></div><br>
 
 
 ---


### PR DESCRIPTION

- closes #67 

made the following changes, as requested in the Issue:

- changed the order of the Quick Links of the project overview page
- changed the text that is linked in the Quick Links
- changed the text of the Quick links
- added a `<br>` at the end of the line of html for the tech-stack-diagram image for better spacing before horizontal bar 

- move Project Write-up link and text up above the Brief Description and below the image for better positioning
- made the header to the section a link to overview page
- made the image a link to overview page

- added a small image of the concept diagram above the Project link at the bottom
- made the image a link to the Project page
- made the text "web application project" a link to the Project page.

